### PR TITLE
fix imp snippet by adding cursor priority to module

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,7 +1,7 @@
 {
   "import": {
     "prefix": "imp",
-    "body": "import $1 from '${module}';$0",
+    "body": "import $1 from '${2:module}';$0",
     "description": "Imports entire module statement in ES6 syntax"
   },
   "importDestructing": {


### PR DESCRIPTION
imp tab caused the snippet to skip $1 and go directly to `${module}` and then to `$0` in v 1.4.0 on OS X.
Fixed by adding cursor priority to the module placeholder.