### PR TITLE
Add snippet for importing ES6 module without module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | Trigger  | Content |
 | -------: | ------- |
 | `imp→`   | imports entire module `import fs from 'fs';`|
+| `imn→`   | imports entire module without module name `import 'animate.css'` |
 | `imd→`   | imports only a portion of the module using destructing  `import {rename} from 'fs';` |
 | `ime→`   | imports everything as alias from the module `import * as localAlias from 'fs';` |
 | `ima→`   | imports only a portion of the module as alias `import { rename  as localRename } from 'fs';` |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -4,6 +4,11 @@
     "body": "import ${2:moduleName} from '${1:module}';$0",
     "description": "Imports entire module statement in ES6 syntax"
   },
+  "importNoModuleName": {
+    "prefix": "imn",
+    "body": "import '${1:module}';$0",
+    "description": "Imports entire module in ES6 syntax without module name"
+  },
   "importDestructing": {
     "prefix": "imd",
     "body": "import { $2 } from '${1:module}';$0",


### PR DESCRIPTION
Add a snippet for `import 'module';`.