### PR TITLE
Fixed typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 ### Console methods
 | Trigger  | Content |
 | -------: | ------- |
-| `cas→`   | console allert method `console.assert(expression, object)`|
+| `cas→`   | console alert method `console.assert(expression, object)`|
 | `ccl→`   | console clear `console.clear()` |
 | `cco→`   | console count `console.count(label)` |
 | `cdi→`   | console dir `console.dir` |

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `fin→`   | for ... in loop `for(let item in object) {}` |
 | `anfn→`  | creates an anonymous function `(params) => {}` |
 | `nfn→`   | creates a named function `const add = (params) => {}` |
-| `dob→`   | desctucting object syntax `const {rename} = fs` |
-| `dar→`   | desctucting array syntax `const [first, second] = [1,2]` |
+| `dob→`   | destructing object syntax `const {rename} = fs` |
+| `dar→`   | destructing array syntax `const [first, second] = [1,2]` |
 | `sti→`   | set interval helper method `setInterval(() => {});` |
 | `sto→`   | set timeout helper method `setTimeout(() => {});` |
 | `prom→`  | creates a new Promise `return new Promise((resolve, reject) => {});`|


### PR DESCRIPTION
First of all, thank you very much for a nice plugin!

As I was checking the list of commands and few typos caught my eye - here they are, all fixed.

Cheers!