### PR TITLE
New snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `imd→`   | imports only a portion of the module using destructing  `import {rename} from 'fs';` |
 | `ime→`   | imports everything as alias from the module `import * as localAlias from 'fs';` |
 | `ima→`   | imports only a portion of the module as alias `import { rename  as localRename } from 'fs';` |
+| `rqr→`   | require package `require('');`|
+| `mde→`   | default module.exports `module.exports = {};`|
 | `enf→`   | exports name function `export const log = (parameter) => { console.log(parameter);};` |
 | `edf→`   | exports default function `export default  (parameter) => { console.log(parameter);};` |
 | `ecl→`   | exports default class `export default class Calculator { };` |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -24,6 +24,11 @@
     "body": "import { ${2:originalName} as ${3:alias} } from '${1:module}';$0",
     "description": "Imports a specific portion of the module by assigning a local alias in ES6 syntax"
   },
+  "require": {
+    "prefix": "rqr",
+    "body": "require('${1:package}');",
+    "description": "Require a package"
+  },
   "exportNamedFunction": {
     "prefix": "enf",
     "body": "export const ${1:functionName} = (${2:params}) =>  {\n\t$0\n};\n",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -29,6 +29,11 @@
     "body": "require('${1:package}');",
     "description": "Require a package"
   },
+  "moduleExports": {
+    "prefix": "mde",
+    "body": "module.exports = {\n\t$0\n};\n",
+    "description": "Module exports from Common JS, node syntax at ES6"
+  },
   "exportNamedFunction": {
     "prefix": "enf",
     "body": "export const ${1:functionName} = (${2:params}) =>  {\n\t$0\n};\n",


### PR DESCRIPTION
Hi, I added two new snippets to improve this awesome plugin

`rqr + tab` return:
```
require('package');
```

and 
`mde + tab` return:
```
module.exports = {

}
```
---
Both snippets ends with a letter near to tab key, this detail makes the typing even faster.