### PR TITLE
Updated README. Fixed trigger for thenCatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `sti→`   | set interval helper method `setInterval(() => {});` |
 | `sto→`   | set timeout helper method `setTimeout(() => {});` |
 | `prom→`  | creates a new Promise `return new Promise((resolve, reject) => {});`|
-| `thenCatch→`| adds then and catch declaration to a promise `.then((res) => {).catch((err) => {});`|
+| `thenc→` | adds then and catch declaration to a promise `.then((res) => {).catch((err) => {});`|
 
 ### Console methods
 | Trigger  | Content |


### PR DESCRIPTION
The trigger was incorrectly documented as `thenCatch` but it's actually `thenc`