### PR TITLE
Add snippets for console.time and console.timeEnd for execution time measurements

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -196,5 +196,15 @@
     "prefix": "clt",
     "body": "console.table(${1:object});",
     "description": "Displays tabular data as a table."
+  },
+  "consoleTime": {
+    "prefix": "cti",
+    "body": "console.time(${1:object});",
+    "description": "Sets starting point for execution time measurement"
+  },
+  "consoleTimeEnd": {
+    "prefix": "cte",
+    "body": "console.timeEnd(${1:object});",
+    "description": "Sets end point for execution time measurement"
   }
 }


### PR DESCRIPTION
PR adds snippets:
```json
   "consoleTime": {
     "prefix": "cti",
     "body": "console.time(${1:object});",
     "description": "Sets starting point for execution time measurement"
   },
   "consoleTimeEnd": {
     "prefix": "cte",
     "body": "console.timeEnd(${1:object});",
     "description": "Sets end point for execution time measurement"
   }
```