### PR TITLE
Is this a typo?

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 ### Console methods
 | Trigger  | Content |
 | -------: | ------- |
-| `cas→`   | console alert method `console.assert(expression, object)`|
+| `cas→`   | console assert method `console.assert(expression, object)`|
 | `ccl→`   | console clear `console.clear()` |
 | `cco→`   | console count `console.count(label)` |
 | `cdi→`   | console dir `console.dir` |


### PR DESCRIPTION
Shouldn't it reads  `console assert method` on README.md:L72 instead of  `console alert method`?