### PR TITLE
change console log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `cgr→`   | console group `console.group(label)` |
 | `cge→`   | console groupEnd `console.groupEnd()` |
 | `clg→`   | console log `console.log(object)` |
-| `clo→`   | console log object with name `console.log('object :', object);` |
+| `clo→`   | console log object with name `console.log('object :>> ', object);` |
 | `ctr→`   | console trace `console.trace(object)` |
 | `cwa→`   | console warn `console.warn` |
 | `cin→`   | console info `console.info` |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -174,7 +174,7 @@
   },
   "consoleLogObject": {
     "prefix": "clo",
-    "body": "console.log('${1:object} :', ${1:object});",
+    "body": "console.log('${1:object} :>> ', ${1:object});",
     "description": "Displays an object in the console with its name"
   },
   "consoleTrace": {


### PR DESCRIPTION
I propose to make the console.log output more expressive. Because the colon is lost in the general log. Perhaps there will be some other thoughts, but it became convenient for me to use this design `:>>`