### PR TITLE
Use single-quote in consoleGroup

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -159,7 +159,7 @@
   },
   "consoleGroup": {
     "prefix": "cgr",
-    "body": "console.group(\"${1:label}\");",
+    "body": "console.group('${1:label}');",
     "description": "Groups and indents all following output by an additional level, until console.groupEnd() is called."
   },
   "consoleGroupEnd": {


### PR DESCRIPTION
Singe quote is more popular, and `consoleLogObject` already uses it. 