### PR TITLE
Include LICENSE in packaged extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,2 @@
 .gitignore
-LICENSE
 CHANGELOG.md


### PR DESCRIPTION
The MIT license says

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

In order to comply with this, the LICENSE file should be included in the published extension.