### PR TITLE
Added snippet for async named function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `fin→`   | for ... in loop `for(const item in object) {}` |
 | `anfn→`  | creates an anonymous function `(params) => {}` |
 | `nfn→`   | creates a named function `const add = (params) => {}` |
+| `asnfn→`   | creates an async named function `const add = async (params) => {}` |
 | `dob→`   | destructing object syntax `const {rename} = fs` |
 | `dar→`   | destructing array syntax `const [first, second] = [1,2]` |
 | `sti→`   | set interval helper method `setInterval(() => {});` |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -111,6 +111,11 @@
     "body": "const ${1:name} = (${2:params}) => {\n\t${3}\n}",
     "description": "Creates a named function in ES6 syntax"
   },
+  "asyncNamedFunction": {
+    "prefix": "asnfn",
+    "body": "const ${1:name} = async (${2:params}) => {\n\t${3}\n}",
+    "description": "Creates an async named function in ES6 syntax"
+  },
   "destructingObject": {
     "prefix": "dob",
     "body": "const {${2:propertyName}} = ${1:objectToDestruct};",


### PR DESCRIPTION
Added snippet for async function because I need it a lot for what I'm doing (I have more async functions than sync). For shortcut, I have it as "asnfn", which is consistent with other functions where "fn" keyword is a suffix. If I could have, I'd have changed all function-based snippets to have "fn" as prefix instead of suffix, but can't change that now. Or can we? ;)