### PR TITLE
feat: export with destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `rqr→`   | require package `require('');`|
 | `req→`   | require package to const `const packageName = require('packageName');`|
 | `mde→`   | default module.exports `module.exports = {};`|
+| `exd→`   | exports only a portion of the module using destructing  `export {rename} from 'fs';` |
+| `env→`   | exports name variable `export const nameVariable = localVariable;` |
 | `env→`   | exports name variable `export const nameVariable = localVariable;` |
 | `enf→`   | exports name function `export const log = (parameter) => { console.log(parameter);};` |
 | `edf→`   | exports default function `export default function fileName (parameter){ console.log(parameter);};` |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -64,6 +64,11 @@
     "body": "export default class ${1:className} extends ${2:baseclassName} {\n\t$0\n};\n",
     "description": "Export default class which extends a base one in ES6 syntax"
   },
+  "exportDestructing": {
+    "prefix": "exd",
+    "body": "export { $2 } from '${1:module}';$0",
+    "description": "Exports only a portion of the module in ES6 syntax"
+  },
 
   "constructor": {
     "prefix": "con",


### PR DESCRIPTION
Adds the shortcut `exd` (regarding [imd](https://github.com/xabikos/vscode-javascript/blob/ecfeba765ebdaff72b23e7a5d030e35c941a7c30/snippets/snippets.json#L13)) to export only a portion of a module in ES6 syntax.

```ts
export { isString } from './utils'
```