### PR TITLE
feat: add export snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `ima→`   | imports only a portion of the module as alias `import { rename  as localRename } from 'fs';` |
 | `rqr→`   | require package `require('');`|
 | `req→`   | require package to const `const packageName = require('packageName');`|
+| `emd→`   | exports only a portion of the module using destructing  `export {rename} from 'fs';` |
+| `eme→`   | exports everything as alias from the module `export * as localAlias from 'fs';`
 | `mde→`   | default module.exports `module.exports = {};`|
 | `env→`   | exports name variable `export const nameVariable = localVariable;` |
 | `enf→`   | exports name function `export const log = (parameter) => { console.log(parameter);};` |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -74,7 +74,7 @@
     "body": "export default class ${1:className} extends ${2:baseclassName} {\n\t$0\n};\n",
     "description": "Export default class which extends a base one in ES6 syntax"
   },
-  
+
   "constructor": {
     "prefix": "con",
     "body": "constructor(${1:params}) {\n\t${0}\n}",
@@ -95,6 +95,7 @@
     "body": "set ${1:propertyName}(${2:value}) {\n\t${0};\n}",
     "description": "Creates a setter property inside a class in ES6 syntax"
   },
+
   "forEach": {
     "prefix": "fre",
     "body": "${1:array}.forEach(${2:currentItem} => {\n\t${0}\n});",
@@ -150,7 +151,7 @@
     "body": ".then((${1:result}) => {\n\t${2}\n}).catch((${3:err}) => {\n\t${4}\n});",
     "description": "Add the .then and .catch methods to handle promises"
   },
-  
+
   "consoleAssert": {
     "prefix": "cas",
     "body": "console.assert(${1:expression}, ${2:object});",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -34,6 +34,16 @@
     "body": "const ${1:packageName} = require('${1:package}');$0",
     "description": "Require a package to const"
   },
+  "exportDestructing": {
+    "prefix": "emd",
+    "body": "export { $2 } from '${1:module}';$0",
+    "description": "Exports only a portion of the module in ES6 syntax"
+  },
+  "exportEverything": {
+    "prefix": "eme",
+    "body": "export * as ${2:alias} from '${1:module}';$0",
+    "description": "Exports everything as alias from the module in ES6 syntax"
+  },
   "moduleExports": {
     "prefix": "mde",
     "body": "module.exports = {\n\t$0\n};\n",
@@ -64,7 +74,7 @@
     "body": "export default class ${1:className} extends ${2:baseclassName} {\n\t$0\n};\n",
     "description": "Export default class which extends a base one in ES6 syntax"
   },
-
+  
   "constructor": {
     "prefix": "con",
     "body": "constructor(${1:params}) {\n\t${0}\n}",
@@ -85,7 +95,6 @@
     "body": "set ${1:propertyName}(${2:value}) {\n\t${0};\n}",
     "description": "Creates a setter property inside a class in ES6 syntax"
   },
-
   "forEach": {
     "prefix": "fre",
     "body": "${1:array}.forEach(${2:currentItem} => {\n\t${0}\n});",
@@ -141,7 +150,7 @@
     "body": ".then((${1:result}) => {\n\t${2}\n}).catch((${3:err}) => {\n\t${4}\n});",
     "description": "Add the .then and .catch methods to handle promises"
   },
-
+  
   "consoleAssert": {
     "prefix": "cas",
     "body": "console.assert(${1:expression}, ${2:object});",
@@ -157,7 +166,7 @@
     "body": "console.count(${1:label});",
     "description": "Writes the the number of times that count() has been invoked at the same line and with the same label"
   },
-    "consoleDebug": {
+  "consoleDebug": {
     "prefix": "cdb",
     "body": "console.debug(${1:object});",
     "description": "Displays a message in the console. Also display a blue right arrow icon along with the logged message in Safari"


### PR DESCRIPTION
Adds the snippets `emd`  and `eme`.

```ts
// emd
export { isString } from './utils'

// eme
export * as Utils from './utils'
```